### PR TITLE
Collapsible nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.js
 node_modules/
 _docs/
 docs/index.md

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,91 @@
+#! /usr/bin/env node
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const shelljs_1 = __importDefault(require("shelljs"));
+const group_by_path_1 = __importDefault(require("./lib/group-by-path"));
+const sort_by_preferences_1 = __importDefault(require("./lib/sort-by-preferences"));
+const markdown_url_to_html_1 = __importDefault(require("./lib/markdown-url-to-html"));
+const markdown_to_html_1 = __importDefault(require("./lib/markdown-to-html"));
+const render_nav_1 = __importDefault(require("./lib/render-nav"));
+const generate_index_info_1 = __importDefault(require("./lib/generate-index-info"));
+const render_page_1 = __importDefault(require("./lib/render-page"));
+const markdown_regex_1 = __importDefault(require("./lib/markdown-regex"));
+const [docsFolder, ...argsRest] = process.argv.slice(2);
+// Default parameters
+const defaultFolder = "docs";
+const folder = docsFolder || defaultFolder;
+const segments = folder.split(path_1.default.sep);
+const currentIndex = segments.length - 1;
+const outputFolder = segments[currentIndex];
+const output = `_${outputFolder}`;
+const templateFilename = "template.html";
+const contentsFilename = "contents.json";
+const preferences = ["index.md", "README.md"];
+// Guards
+// Bail out if more than 1 args
+if (argsRest && argsRest.length > 0) {
+    console.error("Too may arguments");
+    usage(true);
+}
+// Bail out if the folder doesn't exist
+if (!shelljs_1.default.test("-e", folder)) {
+    console.error(`Folder ${folder} not found at ${path_1.default.join(process.cwd(), folder)}`);
+    usage(true);
+}
+// Define template html, user's first, otherwise default
+let template = path_1.default.join(folder, templateFilename);
+if (!shelljs_1.default.test("-e", template)) {
+    template = path_1.default.join(__dirname, defaultFolder, templateFilename);
+}
+const tpl = shelljs_1.default.cat(template);
+// Prepare output folder (create, clean, copy sources)
+shelljs_1.default.mkdir("-p", output);
+shelljs_1.default.rm("-rf", output + "/*");
+shelljs_1.default.cp("-R", folder + "/*", output);
+// Start processing. Outline:
+//
+// 1. Get all files
+// 2. Sort them
+// 3. Group them hierachically
+// 4. Parse files and generate output html files
+shelljs_1.default.cd(output);
+const all = shelljs_1.default.find("*");
+const mds = all
+    .filter(file => file.match(markdown_regex_1.default))
+    .sort(sort_by_preferences_1.default.bind(null, preferences))
+    .map(file => {
+    const content = shelljs_1.default.cat(file).toString(); // The result is a weird not-string
+    return {
+        path: file,
+        url: markdown_url_to_html_1.default(file),
+        content,
+        html: markdown_to_html_1.default(content)
+    };
+});
+const groupedMds = mds.reduce((grouped, value) => group_by_path_1.default(grouped, value.path), []);
+mds.forEach(({ path, url, html }) => {
+    const navHtml = render_nav_1.default(generate_index_info_1.default(path, groupedMds));
+    const pageHtml = render_page_1.default(tpl, navHtml, html);
+    fs_1.default.writeFileSync(url, pageHtml);
+});
+const contentsJSON = {
+    paths: groupedMds,
+    contents: mds.map((md, i) => (Object.assign({}, md, { id: i })))
+};
+fs_1.default.writeFileSync(contentsFilename, JSON.stringify(contentsJSON, null, 2));
+shelljs_1.default.rm("-r", "**/*.md");
+function usage(error) {
+    console.log(`
+Usage:
+
+  markdown-folder-to-html [input-folder]
+
+    input-folder [optional] defaults to \`docs\`
+  `);
+    process.exit(error ? 1 : 0);
+}

--- a/cli.ts
+++ b/cli.ts
@@ -19,7 +19,12 @@ const [docsFolder, ...argsRest] = process.argv.slice(2);
 // Default parameters
 const defaultFolder = "docs";
 const folder = docsFolder || defaultFolder;
-const output = `_${folder}`;
+
+const segments = folder.split(path.sep);
+const currentIndex = segments.length - 1;
+const outputFolder = segments[currentIndex];
+
+const output = `_${outputFolder}`;
 const templateFilename = "template.html";
 const contentsFilename = "contents.json";
 const preferences = ["index.md", "README.md"];

--- a/docs/template.html
+++ b/docs/template.html
@@ -328,6 +328,14 @@
       color: #000;
     }
 
+    #menu li.heading ul {
+      display: none;
+    }
+
+    #menu li.heading.show > ul {
+      display: block;
+    }
+
     #menu li.heading>* {
       padding: 0.5em;
       display: block;
@@ -460,7 +468,8 @@
 
       var layout = document.getElementById('layout'),
         menu = document.getElementById('menu'),
-        menuLink = document.getElementById('menuLink');
+        menuLink = document.getElementById('menuLink'),
+        headings = document.getElementsByClassName('heading');
 
       function toggleClass(element, className) {
         var classes = element.className.split(/\s+/),
@@ -489,6 +498,19 @@
         toggleClass(menu, active);
         toggleClass(menuLink, active);
       };
+
+      for (let index = 0; index < headings.length; index++) {
+        const li = headings[index];
+        const headers = li.getElementsByClassName('header-link');
+
+        for (let headerIndex = 0; headerIndex < headers.length; headerIndex++) {
+          const header = headers[headerIndex];          
+          
+          header.onclick = function() {
+          li.classList.toggle('show');
+        };
+        }
+      }
 
     }(this, this.document));
   </script>

--- a/lib/assert-never.js
+++ b/lib/assert-never.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function assertNever(x) {
+    throw new Error("Unexpected object: " + x);
+}
+exports.default = assertNever;

--- a/lib/generate-index-info.js
+++ b/lib/generate-index-info.js
@@ -1,0 +1,30 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const path_1 = __importDefault(require("path"));
+const path_to_text_1 = __importDefault(require("./path-to-text"));
+const markdown_url_to_html_1 = __importDefault(require("./markdown-url-to-html"));
+const assert_never_1 = __importDefault(require("./assert-never"));
+function generateIndexInfo(currentFile, groupedFiles) {
+    const currentDir = path_1.default.dirname(currentFile);
+    return groupedFiles.map((f) => {
+        if (f.type === "dir") {
+            return {
+                type: "dir",
+                name: path_to_text_1.default(f.name),
+                children: generateIndexInfo(currentFile, f.children)
+            };
+        }
+        else if (f.type === "file") {
+            const active = f.value === currentFile;
+            const href = markdown_url_to_html_1.default(path_1.default.relative(currentDir, f.value));
+            const parts = f.value.split("/");
+            const text = path_to_text_1.default(parts[parts.length - 1]);
+            return { type: "file", value: { active, href, text } };
+        }
+        return assert_never_1.default(f); // Error out if we're not handling all FileNode cases
+    });
+}
+exports.default = generateIndexInfo;

--- a/lib/group-by-path.js
+++ b/lib/group-by-path.js
@@ -1,0 +1,23 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function groupByPath(tree, value) {
+    const paths = value.split("/");
+    let currentTree = tree;
+    paths.forEach((path, i) => {
+        // If we're on the last path segment, we just add it
+        if (i === paths.length - 1) {
+            currentTree.push({ type: "file", value });
+        }
+        else {
+            let folder = currentTree.find(f => f.type === "dir" && f.name === path);
+            // Check again for type file, but we filtered above... typescript stuff
+            if (!folder || folder.type === "file") {
+                folder = { type: "dir", name: path, children: [] };
+                currentTree.push(folder);
+            }
+            currentTree = folder.children;
+        }
+    });
+    return tree;
+}
+exports.default = groupByPath;

--- a/lib/markdown-regex.js
+++ b/lib/markdown-regex.js
@@ -1,0 +1,3 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = /\.md$/;

--- a/lib/markdown-to-html.js
+++ b/lib/markdown-to-html.js
@@ -1,0 +1,39 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const url_1 = __importDefault(require("url"));
+const markdown_it_1 = __importDefault(require("markdown-it"));
+const markdown_url_to_html_1 = __importDefault(require("./markdown-url-to-html"));
+const markdown = markdown_it_1.default({
+    html: true,
+    linkify: true,
+    typographer: true
+}).use(transformLocalMdLinksToHTML);
+function transformLocalMdLinksToHTML(md) {
+    const defaultLinkOpenRender = md.renderer.rules.link_open ||
+        function (tokens, idx, options, env, self) {
+            return self.renderToken(tokens, idx, options);
+        };
+    md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+        const a = tokens[idx];
+        const href = a.attrGet("href");
+        if (href) {
+            a.attrSet("href", localMarkdownLinkToHtmlLink(href));
+        }
+        return defaultLinkOpenRender(tokens, idx, options, env, self);
+    };
+}
+function md2html(contents) {
+    return markdown.render(contents);
+}
+exports.default = md2html;
+function localMarkdownLinkToHtmlLink(hrefAttr) {
+    const href = url_1.default.parse(hrefAttr);
+    if (!href.protocol && !href.host) {
+        // Local link
+        return markdown_url_to_html_1.default(hrefAttr);
+    }
+    return hrefAttr;
+}

--- a/lib/markdown-url-to-html.js
+++ b/lib/markdown-url-to-html.js
@@ -1,0 +1,10 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const markdown_regex_1 = __importDefault(require("./markdown-regex"));
+function mdUrl(file) {
+    return file.replace(markdown_regex_1.default, ".html");
+}
+exports.default = mdUrl;

--- a/lib/path-to-text.js
+++ b/lib/path-to-text.js
@@ -1,0 +1,18 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const markdown_regex_1 = __importDefault(require("./markdown-regex"));
+function pathToText(file, outputPath) {
+    // Remove output folder if there is one
+    return ((outputPath ? file.replace(outputPath + "/", "") : file)
+        // Replace start of folder or file digits \d+ and dash out
+        // 100-banana/10-apple/01-banana -> banana/apple/banana
+        .replace(/(^|\/)(\d+-)/g, "$1")
+        // Remove extension
+        .replace(markdown_regex_1.default, "")
+        // Replace _ and - with spaces
+        .replace(/_|-/g, " "));
+}
+exports.default = pathToText;

--- a/lib/render-nav.js
+++ b/lib/render-nav.js
@@ -1,0 +1,41 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const assert_never_1 = __importDefault(require("./assert-never"));
+function renderNav(groupedFiles, level = 0) {
+    return `<ul>
+${groupedFiles
+        .map(f => {
+        if (f.type === "dir") {
+            const childrenNav = renderNav(f.children, level + 1);
+            const indexFile = getIndexFile(f.children);
+            // Heading with link if there is an index file in the folder
+            if (indexFile) {
+                const link = renderActive(f.name, indexFile.value.href, indexFile.value.active);
+                return `<li class="heading"><a class="header-link">${link}</a>${childrenNav}</li>\n`;
+            }
+            // Heading without link
+            return `<li class="heading"><a class="header-link"><span>${f.name}</span></a>${childrenNav}</li>\n`;
+        }
+        else if (f.type === "file") {
+            //  Leaf
+            const { text, href, active } = f.value;
+            // Skip index files on nested levels since the Heading links to them.
+            if (level > 0 && text && text.toLowerCase() === "index")
+                return;
+            return `<li>${renderActive(text, href, active)}</li>`;
+        }
+        return assert_never_1.default(f);
+    })
+        .join("\n")}
+</ul>`;
+}
+exports.default = renderNav;
+function renderActive(text, href, active) {
+    return `<a class="${active ? "active" : ""}" href="${href}">${text}</a>`;
+}
+function getIndexFile(files) {
+    return files.find(e => e.type === "file" && e.value.text === "index"); // Stupid TS
+}

--- a/lib/render-nav.ts
+++ b/lib/render-nav.ts
@@ -18,10 +18,10 @@ ${groupedFiles
           indexFile.value.href,
           indexFile.value.active
         );
-        return `<li class="heading">${link}</li>\n${childrenNav}`;
+        return `<li class="heading">${link}${childrenNav}</li>\n`;
       }
       // Heading without link
-      return `<li class="heading"><span>${f.name}</span></li>\n${childrenNav}`;
+      return `<li class="heading"><span>${f.name}</span>${childrenNav}</li>\n`;
     } else if (f.type === "file") {
       //  Leaf
       const { text, href, active } = f.value;

--- a/lib/render-nav.ts
+++ b/lib/render-nav.ts
@@ -18,10 +18,10 @@ ${groupedFiles
           indexFile.value.href,
           indexFile.value.active
         );
-        return `<li class="heading">${link}${childrenNav}</li>\n`;
+        return `<li class="heading"><a class="header-link">${link}</a>${childrenNav}</li>\n`;
       }
       // Heading without link
-      return `<li class="heading"><span>${f.name}</span>${childrenNav}</li>\n`;
+      return `<li class="heading"><a class="header-link"><span>${f.name}</span></a>${childrenNav}</li>\n`;
     } else if (f.type === "file") {
       //  Leaf
       const { text, href, active } = f.value;

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const contentS = "<!--CONTENT-->";
+const navS = "<!--NAV-->";
+function renderPage(template, navmenu, content) {
+    return template
+        .split(navS)
+        .join(navmenu)
+        .split(contentS)
+        .join(content);
+}
+exports.default = renderPage;

--- a/lib/sort-by-preferences.js
+++ b/lib/sort-by-preferences.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const isPreferent = (x, preferences) => preferences.indexOf(x) > -1;
+const strSort = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+function sortByPrecedence(preferences, a, b) {
+    const aPref = isPreferent(a, preferences);
+    const bPref = isPreferent(b, preferences);
+    return aPref && bPref
+        ? strSort(a, b)
+        : aPref
+            ? -1
+            : bPref
+                ? 1
+                : strSort(a, b);
+}
+exports.default = sortByPrecedence;

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/test/generate-index-info.js
+++ b/test/generate-index-info.js
@@ -1,0 +1,88 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const tape_1 = __importDefault(require("tape"));
+const group_by_path_1 = __importDefault(require("../lib/group-by-path"));
+const generate_index_info_1 = __importDefault(require("../lib/generate-index-info"));
+const files = [
+    "index.md",
+    "1-banana.md",
+    "nested/another-banana.md",
+    "nested/so_apple.md"
+];
+const grouped = files.reduce(group_by_path_1.default, []);
+// Generate info with the first file as the current one
+const treeInfoFirstIsCurrent = generate_index_info_1.default(files[0], grouped);
+tape_1.default("current file has active property to true", t => {
+    const first = treeInfoFirstIsCurrent[0];
+    t.ok(first.type === "file" && first.value.active);
+    t.end();
+});
+tape_1.default("leaf file has text property that has been parsed", t => {
+    const second = treeInfoFirstIsCurrent[1];
+    t.equal(second.type === "file" && second.value.text, "banana");
+    t.end();
+});
+tape_1.default("nested files are kept in a hierarchy", t => {
+    const third = treeInfoFirstIsCurrent[2];
+    t.equal(third.type, "dir", "The nested tree is a dir");
+    t.equal(third.type === "dir" && third.name, "nested", "Heading is in the first position");
+    t.equal(third.type === "dir" && third.children.length, 2, "Second position has array of children");
+    t.end();
+});
+tape_1.default("whole structure matches (for reference)", t => {
+    // Verify whole structure
+    t.deepEqual(treeInfoFirstIsCurrent, [
+        {
+            type: "file",
+            value: {
+                active: true,
+                href: "index.html",
+                text: "index"
+            }
+        },
+        {
+            type: "file",
+            value: {
+                active: false,
+                href: "1-banana.html",
+                text: "banana"
+            }
+        },
+        {
+            type: "dir",
+            name: "nested",
+            children: [
+                {
+                    type: "file",
+                    value: {
+                        active: false,
+                        href: "nested/another-banana.html",
+                        text: "another banana"
+                    }
+                },
+                {
+                    type: "file",
+                    value: {
+                        active: false,
+                        href: "nested/so_apple.html",
+                        text: "so apple"
+                    }
+                }
+            ]
+        }
+    ]);
+    t.end();
+});
+tape_1.default("properly generates the hrefs as relative paths when current file is a nested one", t => {
+    const treeInfoNestedIsCurrent = generate_index_info_1.default(files[2], grouped);
+    const first = treeInfoNestedIsCurrent[0];
+    const second = treeInfoNestedIsCurrent[1];
+    const third = treeInfoNestedIsCurrent[2];
+    t.equal(first.type === "file" && first.value.href, "../index.html");
+    t.equal(second.type === "file" && second.value.href, "../1-banana.html");
+    t.equal(third.type === "dir" && third.children[1].value.href, "so_apple.html");
+    t.end();
+});

--- a/test/group-by-path.js
+++ b/test/group-by-path.js
@@ -1,0 +1,40 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const tape_1 = __importDefault(require("tape"));
+const group_by_path_1 = __importDefault(require("../lib/group-by-path"));
+tape_1.default("given a group of paths, it groups them in arrays when reducing over them", t => {
+    const paths = [
+        "index",
+        "banana",
+        "nested/banana",
+        "nested/apple",
+        "nested/super nested/thing"
+    ];
+    const groupedPaths = [
+        { type: "file", value: "index" },
+        { type: "file", value: "banana" },
+        {
+            type: "dir",
+            name: "nested",
+            children: [
+                { type: "file", value: "nested/banana" },
+                { type: "file", value: "nested/apple" },
+                {
+                    type: "dir",
+                    name: "super nested",
+                    children: [
+                        {
+                            type: "file",
+                            value: "nested/super nested/thing"
+                        }
+                    ]
+                }
+            ]
+        }
+    ];
+    t.deepEqual(paths.reduce(group_by_path_1.default, []), groupedPaths);
+    t.end();
+});

--- a/test/markdown-regex.js
+++ b/test/markdown-regex.js
@@ -1,0 +1,13 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const tape_1 = __importDefault(require("tape"));
+const markdown_regex_1 = __importDefault(require("../lib/markdown-regex"));
+tape_1.default("matches files with md extension", t => {
+    t.ok(markdown_regex_1.default.test("banana.md"));
+    t.notOk(markdown_regex_1.default.test("banana.md.other"));
+    t.notOk(markdown_regex_1.default.test("bananamd"));
+    t.end();
+});

--- a/test/markdown-to-html.js
+++ b/test/markdown-to-html.js
@@ -1,0 +1,15 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const tape_1 = __importDefault(require("tape"));
+const markdown_to_html_1 = __importDefault(require("../lib/markdown-to-html"));
+tape_1.default("transforms markdown to html", t => {
+    t.equal(markdown_to_html_1.default("**banana** _split_ hey"), "<p><strong>banana</strong> <em>split</em> hey</p>\n");
+    t.end();
+});
+tape_1.default("transforms local markdown links to html links", t => {
+    t.equal(markdown_to_html_1.default("[banana](./banana/split.md)"), '<p><a href="./banana/split.html">banana</a></p>\n');
+    t.end();
+});

--- a/test/markdown-url-to-html.js
+++ b/test/markdown-url-to-html.js
@@ -1,0 +1,11 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const tape_1 = __importDefault(require("tape"));
+const markdown_url_to_html_1 = __importDefault(require("../lib/markdown-url-to-html"));
+tape_1.default("it changes the extension of a markdown url to reference an html file", t => {
+    t.equal(markdown_url_to_html_1.default("banana/split.md"), "banana/split.html");
+    t.end();
+});

--- a/test/path-to-text.js
+++ b/test/path-to-text.js
@@ -1,0 +1,23 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const tape_1 = __importDefault(require("tape"));
+const path_to_text_1 = __importDefault(require("../lib/path-to-text"));
+tape_1.default("gets rid of the markdown extension", t => {
+    t.equal(path_to_text_1.default("banana.md"), "banana");
+    t.end();
+});
+tape_1.default("gets rid of the output dir", t => {
+    t.equal(path_to_text_1.default("_output/banana", "_output"), "banana");
+    t.end();
+});
+tape_1.default("gets rid of numbers at the front of the name on each sub level", t => {
+    t.equal(path_to_text_1.default("1-banana/20-apple/005-tomato/banana"), "banana/apple/tomato/banana");
+    t.end();
+});
+tape_1.default("swaps - and _ for spaces", t => {
+    t.equal(path_to_text_1.default("banana-split/pina_colada"), "banana split/pina colada");
+    t.end();
+});

--- a/test/render-nav.js
+++ b/test/render-nav.js
@@ -1,0 +1,54 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const tape_1 = __importDefault(require("tape"));
+const render_nav_1 = __importDefault(require("../lib/render-nav"));
+tape_1.default("renders a ul with plain index item as a li", t => {
+    t.equal(render_nav_1.default([
+        {
+            type: "file",
+            value: { text: "banana", active: false, href: "bananalink" }
+        }
+    ]), '<ul>\n<li><a class="" href="bananalink">banana</a></li>\n</ul>');
+    t.end();
+});
+tape_1.default("renders a active class when index item is active", t => {
+    t.equal(render_nav_1.default([
+        {
+            type: "file",
+            value: { text: "banana", active: true, href: "bananalink" }
+        }
+    ]), '<ul>\n<li><a class="active" href="bananalink">banana</a></li>\n</ul>');
+    t.end();
+});
+tape_1.default("renders a heading and nested items when index item is array", t => {
+    t.equal(render_nav_1.default([
+        {
+            type: "file",
+            value: { text: "banana", active: true, href: "bananalink" }
+        },
+        {
+            type: "dir",
+            name: "headingtext",
+            children: [
+                {
+                    type: "file",
+                    value: {
+                        text: "apple",
+                        active: false,
+                        href: "applelink"
+                    }
+                }
+            ]
+        }
+    ]), `<ul>
+<li><a class="active" href="bananalink">banana</a></li>
+<li class="heading"><span>headingtext</span></li>
+<ul>
+<li><a class="" href="applelink">apple</a></li>
+</ul>
+</ul>`);
+    t.end();
+});

--- a/test/render-page.js
+++ b/test/render-page.js
@@ -1,0 +1,20 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const tape_1 = __importDefault(require("tape"));
+const render_page_1 = __importDefault(require("../lib/render-page"));
+tape_1.default("Changes instances of <!--NAV--> with the navigation html", t => {
+    t.equal(render_page_1.default("banana <!--NAV--> apple", "split", "tini"), "banana split apple");
+    t.end();
+});
+tape_1.default("Changes instances of <!--CONTENT--> with the page content", t => {
+    t.equal(render_page_1.default("banana <!--CONTENT--> apple", "nav", "tini"), "banana tini apple");
+    t.end();
+});
+tape_1.default("Changes instances of <!--CONTENT--> with the page content", t => {
+    const content = "<p>Hello</p>\n<pre><code>'$KEY$' =&gt; $VALUE$,\n</code></pre>\n<p>This breaks down the rendering?</p>\n";
+    t.equal(render_page_1.default("<!--NAV--> banana <!--CONTENT--> apple", "nav", content), `nav banana ${content} apple`);
+    t.end();
+});

--- a/test/sort-by-preferences.js
+++ b/test/sort-by-preferences.js
@@ -1,0 +1,24 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const tape_1 = __importDefault(require("tape"));
+const sort_by_preferences_1 = __importDefault(require("../lib/sort-by-preferences"));
+const sort = sort_by_preferences_1.default.bind(null, ["index.md", "README.md"]);
+tape_1.default("sorts with normal string sort", t => {
+    t.deepEqual(["a", "C", "A", "B", "~", "ab", "b"].sort(sort), [
+        "A",
+        "B",
+        "C",
+        "a",
+        "ab",
+        "b",
+        "~"
+    ]);
+    t.end();
+});
+tape_1.default("sorts but puts first preferent strings", t => {
+    t.deepEqual(["a", "C", "README.md", "A", "index.md", "B", "~", "ab", "b"].sort(sort), ["README.md", "index.md", "A", "B", "C", "a", "ab", "b", "~"]);
+    t.end();
+});


### PR DESCRIPTION
This pull request adds 1 feature and fixe a bug.

1. It adds support for collapsible node. Now all the nodes are collapsed by default. The selected path does not persist across pages. This'll be a different effort.

2. When generating files from an upstream directory (i.e. ../notes) the first path segment was used to create the output directory. In this example, "_../" was created. With this change, the output directory is now "_notes".