### PR TITLE
feat: add support for anchor links

### DIFF
--- a/lib/markdown-to-html.ts
+++ b/lib/markdown-to-html.ts
@@ -1,12 +1,14 @@
 import url from "url";
 import markdownIt from "markdown-it";
+import markdownItAnchor from "markdown-it-anchor";
 import mdUrl from "./markdown-url-to-html";
 
 const markdown = markdownIt({
   html: true,
   linkify: true,
   typographer: true
-}).use(transformLocalMdLinksToHTML);
+}).use(transformLocalMdLinksToHTML)
+  .use(markdownItAnchor);
 
 function transformLocalMdLinksToHTML(md: any) {
   const defaultLinkOpenRender =

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,15 @@
         "@types/linkify-it": "*"
       }
     },
+    "@types/markdown-it-anchor": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it-anchor/-/markdown-it-anchor-4.0.3.tgz",
+      "integrity": "sha512-L0NDW75vkovFradOQiPsodVkmJhA11LTDOgkJL0bsRvDo7uMWAwJWpC3oDCBCrP4mBJurP+adKZm0FP3GoGnmw==",
+      "dev": true,
+      "requires": {
+        "@types/markdown-it": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -479,6 +488,11 @@
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       }
+    },
+    "markdown-it-anchor": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz",
+      "integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A=="
     },
     "mdurl": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
   "homepage": "https://github.com/joakin/markdown-folder-to-html#readme",
   "dependencies": {
     "markdown-it": "^8.4.2",
+    "markdown-it-anchor": "^5.2.4",
     "shelljs": "^0.8.3"
   },
   "devDependencies": {
     "@types/markdown-it": "0.0.7",
+    "@types/markdown-it-anchor": "^4.0.3",
     "@types/node": "^10.14.4",
     "@types/shelljs": "^0.8.4",
     "@types/tape": "^4.2.33",

--- a/test/markdown-to-html.ts
+++ b/test/markdown-to-html.ts
@@ -17,3 +17,11 @@ test("transforms local markdown links to html links", t => {
   );
   t.end();
 });
+
+test("transforms heading text to ids for anchor links", t => {
+  t.equal(
+    md2html("# Heading 1"),
+    '<h1 id="heading-1">Heading 1</h1>\n'
+  );
+  t.end();
+});


### PR DESCRIPTION
This adds support for anchors via `markdown-it-anchor`. 